### PR TITLE
ENTESB-13173 - Configure Sonar analysis including coverage with jacoco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,19 @@ jobs:
       jdk: openjdk13
       script:
         - mvn verify
+    - stage: deploy
+      name: "Sonar analysis"
+      jdk: openjdk11
+      script:
+        - if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $IS_SNAPSHOT == "true" || -n "$TRAVIS_TAG" && $IS_SNAPSHOT == "false" ]]; then 
+            mvn verify -Dtest="*,!RunnerStandardIOTest,!RunnerWebSocketTest" -B sonar:sonar;
+          fi
+      addons:
+        sonarcloud:
+          organization: "teiid"
+          token:
+            secure: "TggRuDyFbjFNts8bBcoQhVq9a8dAiEN0Y/JqHfprksA+ekvJ7MLhfQCNFCHnWVdCAOCX00jNOrDR/nKLLV7NsCxVGZINYN17Ls4zfYPGXk6hmGAX+E58XM8cBhS/tKO8YSw3mL/L0n8saKOsANwGubUIu4pcUVnAYx2BfhYDcznEUT2NDLhZOc4ZNQdq2fKBgi4vlUVieonqEcdCPpTDIVglqlZZcufiBwtdLKwQN89L4MT+351JkVFiz6JjDTUManmnvkdGP7lL62YJVWH87DsEvxTJlWPBeTslG++yv7ctgeD7AalmkU/WZZ8ycChQORSn6mKB3uKIFQQubyeUPUwGFwBUMy8jcOXCGYcThPSfbPaK4NFUySdPrLKqU5lsDhqf/eXqj2KIqPjxBm0QI2/RQdyjWYLKvqf0Eo1TtetDNA74xM1gpKyh/UsXD5Lfkp3JtLlzgTY1nph/q4A+8aJq/WEFJade4AAQpxa4wqUW7TnY5z1te01z+yvnYdE/Lov7FgVZ3Iy37jBqZYAzwlkGpFFLltgrmpaPyuM31w2Cp/+v+qYuGj41EZm8AcnbhttlnWc+xed6q9sItKCdH33hLpXiH9AHTp2elulV1s062wDe9/gIKHeMV3K7dSpf5BIGXWogjDo2+DFr/NKKIIY7P5fWFXU+W3QxWCmN4hU="
 stages:
  - test
+ - name: deploy
+   if: branch = master AND NOT type = pull_request

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<assertj.version>3.15.0</assertj.version>
 		<awaitility.version>4.0.2</awaitility.version>
 		<tyrus.version>1.16</tyrus.version>
+		<jacoco.version>0.8.5</jacoco.version>
 	</properties>
 
 	<build>
@@ -58,7 +59,19 @@
 					</execution>
 				</executions>
 			</plugin>
-			
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 
 		<pluginManagement>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=teiid-language-server
+sonar.projectName=Teiid Language Server


### PR DESCRIPTION
- note that 2 tests are excluded from coverage due to a bug with several
threads launched in tests and jacoco

SONAR_TOKEN needs to be provided on Travis CI and Teiid organization created on Sonarcloud.io